### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/__tests__/set.test.ts
+++ b/__tests__/set.test.ts
@@ -28,3 +28,8 @@ it('test with object reference', () => {
   expect(data.a.b.c).toEqual(['Hello', 'World']);
   expect(sameReference === data).toEqual(true);
 });
+
+it('test with magic attribute', () => {
+  set(data, '__proto__.polluted', true);
+  expect(({} as any).polluted).toEqual(undefined);
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export default function set(obj: Record<string, any> = {}, path: string, value: any) {
   const [key, ...keys] = path.split('.');
   if (isPrototypePolluted(key))
-    return
+    return;
   const pointer = obj[key] || {};
   obj[key] =
     keys.length < 1
@@ -11,6 +11,6 @@ export default function set(obj: Record<string, any> = {}, path: string, value: 
 }
 
 function isPrototypePolluted(key: any) {
-  const blackLists: any = ['__proto__', 'constructor', 'prototype']
+  const blackLists: any = ['__proto__', 'constructor', 'prototype'];
   return blackLists.includes(key);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,16 @@
 export default function set(obj: Record<string, any> = {}, path: string, value: any) {
   const [key, ...keys] = path.split('.');
+  if (isPrototypePolluted(key))
+    return
   const pointer = obj[key] || {};
   obj[key] =
     keys.length < 1
       ? value
       : set(pointer.toString() === '[object Object]' || Array.isArray(pointer) ? pointer : {}, keys.join('.'), value);
   return obj;
+}
+
+function isPrototypePolluted(key: any) {
+  const blackLists: any = ['__proto__', 'constructor', 'prototype']
+  return blackLists.includes(key);
 }


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/object-set/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/@util-funcs/object-set/1/README.md

### User Comments:

### :bar_chart: Metadata *

`@util-funcs/object-set` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40util-funcs%2Fobject-set

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var set = require("@util-funcs/object-set")
var obj = {}
console.log("Before : " + {}.polluted);
set.default(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @util-funcs/object-set # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104120847-f86fb100-535f-11eb-909b-12964aed2e88.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
